### PR TITLE
chore: update supabase auth helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,11 @@
         "@emotion/styled": "^11.11.5",
         "@google/generative-ai": "^0.11.3",
         "@mui/material": "^5.15.18",
+        "@supabase/auth-helpers-nextjs": "^0.10.0",
         "@supabase/supabase-js": "^2.43.4",
         "chart.js": "^4.4.3",
         "next": "14.2.3",
+        "notistack": "^3.0.1",
         "react": "^18",
         "react-chartjs-2": "^5.2.0",
         "react-dom": "^18"
@@ -1993,6 +1995,33 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@supabase/auth-helpers-nextjs": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-nextjs/-/auth-helpers-nextjs-0.10.0.tgz",
+      "integrity": "sha512-2dfOGsM4yZt0oS4TPiE7bD4vf7EVz7NRz/IJrV6vLg0GP7sMUx8wndv2euLGq4BjN9lUCpu6DG/uCC8j+ylwPg==",
+      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-helpers-shared": "0.7.0",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.39.8"
+      }
+    },
+    "node_modules/@supabase/auth-helpers-shared": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-shared/-/auth-helpers-shared-0.7.0.tgz",
+      "integrity": "sha512-FBFf2ei2R7QC+B/5wWkthMha8Ca2bWHAndN+syfuEUUfufv4mLcAgBCcgNg5nJR8L0gZfyuaxgubtOc9aW3Cpg==",
+      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.14.4"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.39.8"
       }
     },
     "node_modules/@supabase/auth-js": {
@@ -6190,6 +6219,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -8149,6 +8187,15 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8939,6 +8986,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/notistack": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/notistack/-/notistack-3.0.2.tgz",
+      "integrity": "sha512-0R+/arLYbK5Hh7mEfR2adt0tyXJcCC9KkA2hc56FeWik2QN6Bm/S4uW+BjzDARsJth5u06nTjelSw/VSnB1YEA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^1.1.0",
+        "goober": "^2.0.33"
+      },
+      "engines": {
+        "node": ">=12.0.0",
+        "npm": ">=6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/notistack"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/notistack/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/npm-run-path": {
@@ -10120,6 +10198,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -15,10 +15,11 @@
     "@emotion/styled": "^11.11.5",
     "@google/generative-ai": "^0.11.3",
     "@mui/material": "^5.15.18",
+    "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/supabase-js": "^2.43.4",
     "chart.js": "^4.4.3",
-    "notistack": "^3.0.1",
     "next": "14.2.3",
+    "notistack": "^3.0.1",
     "react": "^18",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18"
@@ -27,11 +28,11 @@
     "@testing-library/jest-dom": "^6.4.5",
     "@testing-library/react": "^15.0.7",
     "@testing-library/user-event": "^14.5.2",
+    "cypress": "^13.9.0",
+    "dotenv": "^16.4.5",
     "eslint": "^8",
     "eslint-config-next": "14.2.3",
     "jest": "^29.7.0",
-    "jest-environment-jsdom": "^29.7.0",
-    "dotenv": "^16.4.5",
-    "cypress": "^13.9.0"
+    "jest-environment-jsdom": "^29.7.0"
   }
 }

--- a/pages/api/dashboard-stats.js
+++ b/pages/api/dashboard-stats.js
@@ -1,12 +1,13 @@
-import { supabase } from '../../lib/supabaseClient';
+import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs';
 
 export default async function handler(req, res) {
+  const supabase = createServerSupabaseClient({ req, res });
   if (req.method !== 'GET') {
     res.setHeader('Allow', ['GET']);
     return res.status(405).end('Method Not Allowed');
   }
 
-  const { user } = await supabase.auth.api.getUserByCookie(req);
+  const { data: { user } } = await supabase.auth.getUser();
   if (!user) {
     return res.status(401).json({ error: 'Unauthorized' });
   }

--- a/pages/api/mi-ruta.js
+++ b/pages/api/mi-ruta.js
@@ -1,6 +1,7 @@
-import { supabase } from '../../lib/supabaseClient';
+import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs';
 
 export default async function handler(req, res) {
+  const supabase = createServerSupabaseClient({ req, res });
   if (req.method !== 'GET') {
     res.setHeader('Allow', ['GET']);
     return res.status(405).end('Method Not Allowed');
@@ -8,7 +9,7 @@ export default async function handler(req, res) {
 
   // Get the authenticated user from the cookie.
   // In a real application, the user's ID might be a UUID. Here we assume it's text.
-  const { user } = await supabase.auth.api.getUserByCookie(req);
+  const { data: { user } } = await supabase.auth.getUser();
   if (!user) {
     return res.status(401).json({ error: 'Unauthorized' });
   }

--- a/pages/api/puntos-de-venta.js
+++ b/pages/api/puntos-de-venta.js
@@ -1,9 +1,10 @@
-import { supabase } from '../../lib/supabaseClient';
+import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs';
 
 export default async function handler(req, res) {
+  const supabase = createServerSupabaseClient({ req, res });
   // A simple way to protect the API route.
   // We're checking for a session on the server-side.
-  const { user } = await supabase.auth.api.getUserByCookie(req);
+  const { data: { user } } = await supabase.auth.getUser();
   if (!user) {
     return res.status(401).json({ error: 'Unauthorized' });
   }

--- a/pages/api/rutas.js
+++ b/pages/api/rutas.js
@@ -1,7 +1,8 @@
-import { supabase } from '../../lib/supabaseClient';
+import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs';
 
 export default async function handler(req, res) {
-  const { user } = await supabase.auth.api.getUserByCookie(req);
+  const supabase = createServerSupabaseClient({ req, res });
+  const { data: { user } } = await supabase.auth.getUser();
   if (!user) {
     return res.status(401).json({ error: 'Unauthorized' });
   }

--- a/pages/api/users.js
+++ b/pages/api/users.js
@@ -1,7 +1,8 @@
-import { supabase } from '../../lib/supabaseClient';
+import { createServerSupabaseClient } from '@supabase/auth-helpers-nextjs';
 
 export default async function handler(req, res) {
-  const { user } = await supabase.auth.api.getUserByCookie(req);
+  const supabase = createServerSupabaseClient({ req, res });
+  const { data: { user } } = await supabase.auth.getUser();
   if (!user) {
     return res.status(401).json({ error: 'Unauthorized' });
   }


### PR DESCRIPTION
## Summary
- install `@supabase/auth-helpers-nextjs`
- refactor API routes to use `createServerSupabaseClient` and `auth.getUser`

## Testing
- `npm test` *(fails: Unable to find a label with the text of: /email/i)*
- `npm run lint` *(prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68908e4c3a448326ac90cab6f73e8c54