### PR TITLE
Validate Supabase credentials before initializing client

### DIFF
--- a/__tests__/DashboardPage.test.js
+++ b/__tests__/DashboardPage.test.js
@@ -13,7 +13,10 @@ jest.mock('next/router', () => ({
 }));
 
 jest.mock('../context/Auth', () => ({
-  useAuth: () => ({ user: { email: 'test@example.com' } }),
+  useAuth: () => ({
+    user: { email: 'test@example.com' },
+    profile: { role: 'supervisor' },
+  }),
 }));
 
 // Mock Chart.js components
@@ -54,7 +57,7 @@ describe('DashboardPage', () => {
     render(<DashboardPage />);
 
     // Check for loading state first
-    expect(screen.getByText(/cargando dashboard/i)).toBeInTheDocument();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
 
     // Wait for the data to be loaded and rendered
     await waitFor(() => {
@@ -74,12 +77,12 @@ describe('DashboardPage', () => {
   });
 
   it('renders an error message if the fetch fails', async () => {
-    fetch.mockRejectedValueOnce(new Error('Failed to fetch stats'));
+    fetch.mockImplementationOnce(() => Promise.reject(new Error('Failed to fetch stats')));
 
     render(<DashboardPage />);
 
     await waitFor(() => {
-      expect(screen.getByText(/error: failed to fetch stats/i)).toBeInTheDocument();
+      expect(screen.getByText(/failed to fetch stats/i)).toBeInTheDocument();
     });
   });
 });

--- a/__tests__/HomePage.test.js
+++ b/__tests__/HomePage.test.js
@@ -77,6 +77,6 @@ describe('HomePage', () => {
 
     render(<HomePage />);
 
-    expect(screen.getByText(/cargando/i)).toBeInTheDocument();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });
 });

--- a/__tests__/LoginPage.test.js
+++ b/__tests__/LoginPage.test.js
@@ -26,7 +26,7 @@ describe('LoginPage', () => {
     expect(screen.getByRole('heading', { name: /iniciar sesión/i })).toBeInTheDocument();
 
     // Check for form fields by their labels
-    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/correo electr/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/contraseña/i)).toBeInTheDocument();
 
     // Check for the submit button

--- a/lib/supabaseClient.js
+++ b/lib/supabaseClient.js
@@ -4,4 +4,11 @@ import { createClient } from '@supabase/supabase-js'
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
 
+if (!supabaseUrl || !supabaseAnonKey) {
+  if (process.env.NODE_ENV === 'development') {
+    console.warn('Supabase credentials missing')
+  }
+  throw new Error('Supabase credentials missing')
+}
+
 export const supabase = createClient(supabaseUrl, supabaseAnonKey)


### PR DESCRIPTION
## Summary
- ensure Supabase environment variables exist before creating client
- log a warning in development and throw if credentials are missing
- update Jest tests to match Spanish labels and spinner-based loading states

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6890969145508326b39a451fbb568049