### PR TITLE
refactor: remove unused router hooks

### DIFF
--- a/pages/puntos-de-venta.js
+++ b/pages/puntos-de-venta.js
@@ -1,6 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../context/Auth';
-import { useRouter } from 'next/router';
 import {
   Typography, Button, Grid, Paper, TextField, Table,
   TableBody, TableCell, TableContainer, TableHead, TableRow,
@@ -12,7 +11,6 @@ import { useSnackbar } from 'notistack';
 
 export default function PuntosDeVentaPage() {
   const { user, profile } = useAuth();
-  const router = useRouter();
   const { enqueueSnackbar } = useSnackbar();
   const [puntos, setPuntos] = useState([]);
   const [loading, setLoading] = useState(true);

--- a/pages/rutas.js
+++ b/pages/rutas.js
@@ -1,6 +1,5 @@
 import { useState, useEffect, Fragment, useCallback } from 'react';
 import { useAuth } from '../context/Auth';
-import { useRouter } from 'next/router';
 import {
   Box, Typography, Button, Grid, Paper, TextField,
   Table, TableBody, TableCell, TableContainer, TableHead, TableRow,
@@ -13,7 +12,6 @@ import { useSnackbar } from 'notistack';
 
 export default function RutasPage() {
   const { user, profile } = useAuth();
-  const router = useRouter();
   const { enqueueSnackbar } = useSnackbar();
 
   const [rutas, setRutas] = useState([]);


### PR DESCRIPTION
## Summary
- remove unused `useRouter` import and constant from `pages/rutas.js`
- remove unused `useRouter` import and constant from `pages/puntos-de-venta.js`

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_6890c111d5e88326aee910abd141ae76